### PR TITLE
adding withdraw blocker functionality

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -13,5 +13,6 @@
 	"deposit_info": "Please deposit to:",
 	"gift_sent": "Sent you {{amount}} {{tokenSymbol}}",
 	"no_gifts": "Can't send you any tokens",
-	"deposit_received": "Deposit has been received, your new balance is: {{updatedBalance}} {{tokenSymbol}}"
+	"deposit_received": "Deposit has been received, your new balance is: {{updatedBalance}} {{tokenSymbol}}",
+	"withdraw_in_progress": "Withdraw is already currently in progress"
 }

--- a/index.js
+++ b/index.js
@@ -166,9 +166,6 @@ token.getTokenInfo().then(function (tokenInfo) {
           if (!result) {
             console.error('Withdraw error');
             // remove userId from array upon error
-            if (index > -1) {
-                currentUser.splice(index, 1);
-            }
             throw 'not_enough_funds_error';
           }
           return database.getBalanceForUserId(msg.from.id);
@@ -186,9 +183,6 @@ token.getTokenInfo().then(function (tokenInfo) {
           if (txos.length === 0) {
             console.error('No txos or all txos unconfirmed');
             // remove userId from array upon error
-            if (index > -1) {
-                currentUser.splice(index, 1);
-            }
             throw 'not_enough_txos';
           }
           return token.withdraw(address, amount, txos);

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ token.getTokenInfo().then(function (tokenInfo) {
       let newBalance;
       let currentBalance = 0;
       let userId = msg.from.id;
-      const index = currentUser.indexOf(userId);
+      
 
       // check if userId already exists in array
       if(currentUser.indexOf(userId) != -1){
@@ -197,6 +197,7 @@ token.getTokenInfo().then(function (tokenInfo) {
             console.info('Withdraw completed: %s to user %s txd: %s', amount, msg.from.id, transactionId);
             
             // withdraw completed, remove userId so they can submit another withdraw
+            const index = currentUser.indexOf(userId);
             if (index > -1) {
                 currentUser.splice(index, 1);
             }
@@ -211,6 +212,7 @@ token.getTokenInfo().then(function (tokenInfo) {
             responseMessage = "Unable to send funds at this time. Please try again later."
           }
           // remove userId from array upon error
+          const index = currentUser.indexOf(userId);
           if (index > -1) {
             currentUser.splice(index, 1);
           }


### PR DESCRIPTION
Using an array, the bot stores the userId during a withdraw request. The bot rejects any further withdraw requests while that userId is present. The userId is spliced out from the array upon any errors or a successful withdraw, allowing the user to once again make a withdraw. Working as expected for me, may not be too pretty or best way about it. 

Thanks,
BitcoinCash@KeepBitcoinFree.org 